### PR TITLE
feat: add refresh functionality for under-radar bills

### DIFF
--- a/src/app/api/feed/under-radar-bills/route.ts
+++ b/src/app/api/feed/under-radar-bills/route.ts
@@ -1,109 +1,81 @@
 import { NextResponse } from 'next/server'
 import { getSupabaseAdmin } from '@/lib/supabase-admin'
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const { searchParams } = new URL(request.url)
+    const refresh = searchParams.get('refresh') === 'true'
+    
     const supabase = getSupabaseAdmin()
     
     // First, ensure we have engagement metrics for all active bills
     await initializeEngagementMetrics(supabase)
     
-    // Query for under-the-radar bills based on real engagement metrics
-    const { data: underRadarBills, error } = await supabase
-      .from('bill_engagement_metrics' as any)
-      .select(`
-        bill_id,
-        under_radar_score,
-        total_votes,
-        support_count,
-        oppose_count,
-        analysis_requests,
-        feedback_count,
-        popularity_score,
-        last_activity_at
-      `)
-      .gt('under_radar_score', 60) // Only bills with significant under-radar potential
-      .lt('total_votes', 15) // Low engagement
-      .order('under_radar_score', { ascending: false })
-      .limit(10)
-
-    if (error) {
-      console.error('Error fetching under-radar bills:', error)
-      return NextResponse.json({ bills: [] })
-    }
-
-    // Get bill details separately
-    const billIds = underRadarBills?.map((item: any) => item.bill_id) || []
-    
-    let billDetails: any[] = []
-    if (billIds.length > 0) {
-      const { data: bills, error: billsError } = await supabase
-        .from('bills')
+    // For refresh mode, we want more variety - get a larger pool and use different sorting
+    if (refresh) {
+      // Get a larger pool with more varied criteria for refresh
+      const { data: underRadarBills, error } = await supabase
+        .from('bill_engagement_metrics' as any)
         .select(`
           bill_id,
-          title,
-          latest_action,
-          policy_area,
-          latest_action_date,
-          sponsor_name,
-          sponsor_party,
-          introduced_date,
-          cboc_estimate_url,
-          constitutional_authority_text
+          under_radar_score,
+          total_votes,
+          support_count,
+          oppose_count,
+          analysis_requests,
+          feedback_count,
+          popularity_score,
+          last_activity_at
         `)
-        .in('bill_id', billIds)
+        .gt('under_radar_score', 45) // Lower threshold for more variety
+        .lt('total_votes', 20) // Slightly higher vote threshold
+        .limit(50) // Get many more bills for better randomization
 
-      if (billsError) {
-        console.error('Error fetching bill details:', billsError)
-      } else {
-        billDetails = bills || []
+      if (error) {
+        console.error('Error fetching under-radar bills:', error)
+        return NextResponse.json({ bills: [] })
       }
-    }
 
-    // Format the response
-    const formattedBills = underRadarBills?.map((item: any) => {
-      const billDetail = billDetails.find((bill: any) => bill.bill_id === item.bill_id)
+      // Randomize the entire array, then take the first 10
+      const billsArray = underRadarBills || []
+      const shuffledBills = billsArray
+        .map((bill: any) => ({ ...bill, randomSort: Math.random() }))
+        .sort((a: any, b: any) => a.randomSort - b.randomSort)
+        .slice(0, 10)
+
+      return await formatAndReturnBills(supabase, shuffledBills, true)
       
-      return {
-        bill_id: item.bill_id,
-        title: billDetail?.title || `Bill ${item.bill_id}`,
-        fiscal_impact: generateFiscalImpactDescription(billDetail),
-        policy_areas: billDetail?.policy_area ? [billDetail.policy_area] : ['General'],
-        analysis_count: item.analysis_requests || 0,
-        total_votes: item.total_votes || 0,
-        importance_score: Math.round(item.under_radar_score || 0),
-        latest_action: billDetail?.latest_action || 'Under review',
-        latest_action_date: billDetail?.latest_action_date,
-        sponsor_name: billDetail?.sponsor_name,
-        sponsor_party: billDetail?.sponsor_party,
-        introduced_date: billDetail?.introduced_date,
-        has_constitutional_authority: !!billDetail?.constitutional_authority_text,
-        has_fiscal_impact: !!billDetail?.cboc_estimate_url,
-        engagement_deficit: calculateEngagementDeficit(item),
-        why_under_radar: generateUnderRadarReason(item, billDetail)
-      }
-    }) || []
+    } else {
+      // Default behavior - get top bills by score
+      const { data: underRadarBills, error } = await supabase
+        .from('bill_engagement_metrics' as any)
+        .select(`
+          bill_id,
+          under_radar_score,
+          total_votes,
+          support_count,
+          oppose_count,
+          analysis_requests,
+          feedback_count,
+          popularity_score,
+          last_activity_at
+        `)
+        .gt('under_radar_score', 60) // Higher threshold for quality
+        .lt('total_votes', 15) // Low engagement
+        .order('under_radar_score', { ascending: false })
+        .limit(10)
 
-    // Sort by importance score (highest first)
-    const sortedBills = formattedBills.sort((a, b) => b.importance_score - a.importance_score)
-
-    return NextResponse.json({ 
-      bills: sortedBills,
-      metadata: {
-        total_count: sortedBills.length,
-        last_updated: new Date().toISOString(),
-        calculation_method: 'dynamic_engagement_metrics',
-        criteria: {
-          max_votes: 15,
-          min_importance_score: 60,
-          factors_considered: ['fiscal_impact', 'constitutional_authority', 'policy_area', 'engagement_deficit']
-        }
+      if (error) {
+        console.error('Error fetching under-radar bills:', error)
+        return NextResponse.json({ bills: [] })
       }
-    })
+
+      return await formatAndReturnBills(supabase, underRadarBills || [], false)
+    }
+    
   } catch (error) {
     console.error('Error in under-radar bills API:', error)
     
-    // Return fallback message instead of hardcoded data
     return NextResponse.json({ 
       bills: [],
       error: 'Unable to load under-the-radar bills. Please try again later.',
@@ -113,6 +85,81 @@ export async function GET() {
       }
     })
   }
+}
+
+/**
+ * Format bills and return response
+ */
+async function formatAndReturnBills(supabase: any, selectedBills: any[], isRefresh: boolean) {
+  // Get bill details separately
+  const billIds = selectedBills?.map((item: any) => item.bill_id) || []
+  
+  let billDetails: any[] = []
+  if (billIds.length > 0) {
+    const { data: bills, error: billsError } = await supabase
+      .from('bills')
+      .select(`
+        bill_id,
+        title,
+        latest_action,
+        policy_area,
+        latest_action_date,
+        sponsor_name,
+        sponsor_party,
+        introduced_date,
+        cboc_estimate_url,
+        constitutional_authority_text
+      `)
+      .in('bill_id', billIds)
+
+    if (billsError) {
+      console.error('Error fetching bill details:', billsError)
+    } else {
+      billDetails = bills || []
+    }
+  }
+
+  // Format the response with reduced randomization for consistency
+  const formattedBills = selectedBills?.map((item: any) => {
+    const billDetail = billDetails.find((bill: any) => bill.bill_id === item.bill_id)
+    
+    return {
+      bill_id: item.bill_id,
+      title: billDetail?.title || `Bill ${item.bill_id}`,
+      fiscal_impact: generateFiscalImpactDescription(billDetail),
+      policy_areas: billDetail?.policy_area ? [billDetail.policy_area] : ['General'],
+      analysis_count: item.analysis_requests || 0,
+      total_votes: item.total_votes || 0,
+      importance_score: calculateDynamicImportanceScore(item, billDetail, isRefresh),
+      latest_action: billDetail?.latest_action || 'Under review',
+      latest_action_date: billDetail?.latest_action_date,
+      sponsor_name: billDetail?.sponsor_name,
+      sponsor_party: billDetail?.sponsor_party,
+      introduced_date: billDetail?.introduced_date,
+      has_constitutional_authority: !!billDetail?.constitutional_authority_text,
+      has_fiscal_impact: !!billDetail?.cboc_estimate_url,
+      engagement_deficit: calculateEngagementDeficit(item),
+      why_under_radar: generateUnderRadarReason(item, billDetail)
+    }
+  }) || []
+
+  // Sort by importance score (highest first)
+  const sortedBills = formattedBills.sort((a, b) => b.importance_score - a.importance_score)
+
+  return NextResponse.json({ 
+    bills: sortedBills,
+    metadata: {
+      total_count: sortedBills.length,
+      last_updated: new Date().toISOString(),
+      calculation_method: 'dynamic_engagement_metrics',
+      is_refresh: isRefresh,
+      criteria: {
+        max_votes: isRefresh ? 20 : 15,
+        min_importance_score: isRefresh ? 45 : 60,
+        factors_considered: ['fiscal_impact', 'constitutional_authority', 'policy_area', 'engagement_deficit']
+      }
+    }
+  })
 }
 
 /**
@@ -237,4 +284,76 @@ function generateUnderRadarReason(item: any, billDetail: any): string {
   }
   
   return reasons.join('; ')
+} 
+
+/**
+ * Calculate dynamic importance score based on multiple factors
+ */
+function calculateDynamicImportanceScore(item: any, billDetail: any, isRefresh: boolean): number {
+  let score = 35; // Reduced base score
+  
+  // Policy area impact (0-20 points, reduced from 25)
+  const highImpactAreas = ['Health', 'Education', 'Energy', 'Taxation', 'National Security', 'Environment']
+  const mediumImpactAreas = ['Transportation', 'Science, Technology, Communications', 'Finance and Financial Sector']
+  
+  if (highImpactAreas.includes(billDetail?.policy_area)) {
+    score += 20 // Reduced from 25
+  } else if (mediumImpactAreas.includes(billDetail?.policy_area)) {
+    score += 12 // Reduced from 15
+  } else {
+    score += 3 // Reduced from 5
+  }
+  
+  // Fiscal impact (0-15 points, reduced from 20)
+  if (billDetail?.cboc_estimate_url) {
+    score += 15 // Reduced from 20
+  }
+  
+  // Constitutional authority (0-10 points, reduced from 15)
+  if (billDetail?.constitutional_authority_text) {
+    score += 10 // Reduced from 15
+  }
+  
+  // Title complexity/length indicator (0-8 points, reduced from 10)
+  const titleLength = billDetail?.title?.length || 0
+  if (titleLength > 100) {
+    score += 8 // Very complex legislation
+  } else if (titleLength > 80) {
+    score += 6 // Reduced from 10
+  } else if (titleLength > 50) {
+    score += 3 // Reduced from 5
+  }
+  
+  // Engagement deficit bonus (0-12 points, reduced from 15)
+  const totalVotes = item.total_votes || 0
+  const analysisRequests = item.analysis_requests || 0
+  
+  if (totalVotes === 0 && analysisRequests === 0) {
+    score += 12 // Reduced from 15 - Completely ignored bills
+  } else if (totalVotes <= 2) {
+    score += 8 // Reduced from 10 - Very low engagement
+  } else if (totalVotes <= 5) {
+    score += 4 // Reduced from 5 - Low engagement
+  }
+  
+  // Time-based adjustment (0-8 points, reduced from 10)
+  if (billDetail?.introduced_date) {
+    const daysSinceIntroduced = Math.floor((Date.now() - new Date(billDetail.introduced_date).getTime()) / (1000 * 60 * 60 * 24))
+    if (daysSinceIntroduced > 180) {
+      score += 8 // Reduced from 10 - Been around for 6+ months
+    } else if (daysSinceIntroduced > 90) {
+      score += 6 // 3+ months
+    } else if (daysSinceIntroduced > 30) {
+      score += 3 // Reduced from 5 - 1+ months
+    }
+  }
+  
+  // Add some randomization to avoid identical scores (less variation for refresh)
+  const randomRange = isRefresh ? 6 : 15 // Reduce randomization on refresh
+  const randomOffset = isRefresh ? 3 : 7
+  const randomAdjustment = Math.floor(Math.random() * randomRange) - randomOffset
+  score += randomAdjustment
+  
+  // Ensure score stays within reasonable bounds with better distribution
+  return Math.max(40, Math.min(100, Math.round(score)))
 } 

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -9,7 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { 
   User, MessageCircle, Users, ThumbsUp, ThumbsDown, Sparkles, Calendar, MapPin, 
-  Search, TrendingUp, Eye, EyeOff, Filter, Clock, AlertTriangle, FileText
+  Search, TrendingUp, Eye, EyeOff, Filter, Clock, AlertTriangle, FileText, RefreshCw
 } from 'lucide-react'
 import Link from 'next/link'
 import { AuthGuard } from '@/components/auth'
@@ -287,10 +287,11 @@ export default function EnhancedFeedPage() {
   }
 
   // Load under-the-radar bills
-  const loadUnderRadarBills = async () => {
+  const loadUnderRadarBills = async (refresh = false) => {
     setRadarLoading(true)
     try {
-      const response = await fetch('/api/feed/under-radar-bills')
+      const url = refresh ? '/api/feed/under-radar-bills?refresh=true' : '/api/feed/under-radar-bills'
+      const response = await fetch(url)
       if (response.ok) {
         const data = await response.json()
         setUnderRadarBills(data.bills || [])
@@ -311,6 +312,11 @@ export default function EnhancedFeedPage() {
     } finally {
       setRadarLoading(false)
     }
+  }
+
+  // Handle refresh for under-radar bills
+  const handleRefreshUnderRadarBills = () => {
+    loadUnderRadarBills(true)
   }
 
   // Handle message signing
@@ -983,13 +989,27 @@ export default function EnhancedFeedPage() {
             <TabsContent value="radar" className="space-y-6">
               <Card>
                 <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    <AlertTriangle className="h-5 w-5" />
-                    Under-the-Radar Bills
-                  </CardTitle>
-                  <p className="text-sm text-gray-600">
-                    Important legislation with significant impact but low public attention
-                  </p>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <CardTitle className="flex items-center gap-2">
+                        <AlertTriangle className="h-5 w-5" />
+                        Under-the-Radar Bills
+                      </CardTitle>
+                      <p className="text-sm text-gray-600">
+                        Important legislation with significant impact but low public attention
+                      </p>
+                    </div>
+                    <Button
+                      onClick={handleRefreshUnderRadarBills}
+                      variant="outline"
+                      size="sm"
+                      disabled={radarLoading}
+                      className="flex items-center gap-2"
+                    >
+                      <RefreshCw className={`h-4 w-4 ${radarLoading ? 'animate-spin' : ''}`} />
+                      Refresh
+                    </Button>
+                  </div>
                 </CardHeader>
                 <CardContent>
                   {radarLoading ? (


### PR DESCRIPTION
- Add refresh button to under-radar bills section with spinning loading indicator
- Implement dynamic importance scoring with multiple factors (policy area, fiscal impact, engagement, etc.)
- Add API parameter to fetch randomized bill selection on refresh
- Improve bill variety by using broader criteria and proper randomization
- Reduce score variation on refresh for consistency while maintaining bill diversity
- Replace hardcoded 75/100 scores with calculated scores ranging from 45-100